### PR TITLE
ci: add buildkite build api url to the output variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The following outputs are provided by the action:
 |Output var|Description|
 |-|-|
 |url|The URL of the Buildkite build.|
+|apiUrl|The api endpoint of the Buildkite build.|
 |json|The JSON response returned by the Buildkite API.|
 
 ## Development

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,7 +65,11 @@ echo "Build created:"
 URL=$(jq --raw-output ".web_url" <<< "$RESPONSE")
 echo $URL
 
-# Provide JSON and Web URL as outputs for downstream actions
+API_URL=$(jq --raw-output ".url" <<< "$RESPONSE")
+echo $API_URL
+
+# Provide JSON, Web URL and api URL as outputs for downstream actions
 echo "::set-output name=json::$RESPONSE"
 echo "::set-output name=url::$URL"
+echo "::set-output name=apiUrl::$API_URL"
 


### PR DESCRIPTION
The api url for the buildkite build is needed to be able to check for the build status to solve [this](https://tinkab.atlassian.net/browse/EPN-893?atlOrigin=eyJpIjoiMjJmZWMyOTY2MGMwNDMwOTkzMWY0NzNhN2FmNWRmNTgiLCJwIjoiaiJ9) jira ticket.